### PR TITLE
Update angular-material-datetimepicker.js

### DIFF
--- a/js/angular-material-datetimepicker.js
+++ b/js/angular-material-datetimepicker.js
@@ -291,6 +291,7 @@
 
               scope.clear = function() {
                 ngModel.$setViewValue(null);
+                scope.currentDate = null;
                 ngModel.$render();
                 $timeout(function() {
                   element[0].focus();


### PR DESCRIPTION
Hey,
Enabling show-icon and then clicking on "X" icon was not resetting the ng-model value in my parent controller. I sniffed around the code and realized that currentDate value (which is derived from ngModel) was not being reset. So, I assigned it to null and everything worked perfectly.
I hope you agree. Thanks!